### PR TITLE
Fix enum display in ticket templates

### DIFF
--- a/templates/ticket/index.html.twig
+++ b/templates/ticket/index.html.twig
@@ -23,8 +23,8 @@
                 <td>{{ ticket.id }}</td>
                 <td>{{ ticket.titre }}</td>
                 <td>{{ ticket.description }}</td>
-                <td>{{ ticket.priorite }}</td>
-                <td>{{ ticket.statut }}</td>
+                <td>{{ ticket.priorite.value }}</td>
+                <td>{{ ticket.statut.value }}</td>
                 <td>{{ ticket.createdAt ? ticket.createdAt|date('Y-m-d H:i:s') : '' }}</td>
                 <td>
                     <a href="{{ path('app_ticket_show', {'id': ticket.id}) }}">show</a>

--- a/templates/ticket/show.html.twig
+++ b/templates/ticket/show.html.twig
@@ -21,11 +21,11 @@
             </tr>
             <tr>
                 <th>Priorite</th>
-                <td>{{ ticket.priorite }}</td>
+                <td>{{ ticket.priorite.value }}</td>
             </tr>
             <tr>
                 <th>Statut</th>
-                <td>{{ ticket.statut }}</td>
+                <td>{{ ticket.statut.value }}</td>
             </tr>
             <tr>
                 <th>CreatedAt</th>


### PR DESCRIPTION
## Summary
- show enum values in templates that display tickets

## Testing
- `composer install` *(fails: CONNECT tunnel failed for https://cdn.jsdelivr.net)*
- `vendor/bin/phpunit --configuration phpunit.dist.xml` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687651ba4ca083288281d0a26ce4cf9c